### PR TITLE
add /venv/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 Gemfile.lock
 *.gem
 .jekyll-cache
+/venv


### PR DESCRIPTION
Most problem exists because of it requires to use virtual env on client side, if the client doesn't have any packages that the moderator/admin have